### PR TITLE
Avoiding to remove end-of-lines

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -199,7 +199,7 @@
       lastLine = endLineNum + lineOffset;
       prevNode = node;
     }
-    return unlines(inputLines).replace(/\n$/, '');
+    return unlines(inputLines);
   };
   module.exports = {
     replace: replace

--- a/src/replace.ls
+++ b/src/replace.ls
@@ -154,6 +154,6 @@ replace = (replacement, input, nodes, query-engine) ->
     last-line := end-line-num + line-offset
     prev-node := node
 
-  unlines input-lines .replace /\n$/, ''
+  unlines input-lines 
 
 module.exports = {replace}


### PR DESCRIPTION
Hello, 

First, thanks for providing such a needed tool for javascript. I greatly appreciate it! 

While using grasp to refactor some code, I noticed that it removes the carriage returns a the end of files that are otherwise untouched by the refactoring. 

I find it very obtrusive as it modifies source controlled files with unwanted or at least, unexpected changes. 

So, I'm submitting this pull request for you to review and discuss!

Note: I left tests untouched as they weren't running at the time I made the PR. 

Thanks for your answer!
