### PR TITLE
add test case for nested typed expression

### DIFF
--- a/test/replace.ls
+++ b/test/replace.ls
@@ -188,6 +188,9 @@ suite 'replace' ->
     test 'equery with {} in replacement' ->
       eq '--equery --replace "f({{__ && {} }})" "__ && __"', 'var a = f(b && {});', it, {input: 'var a = b && {};'}
 
+    test 'equery with nested typed expression (GH #62)' ->
+      eq '--equery --replace "{{e}}.qux({{_str$s}})" "$e.baz(_str$s)"', 'foo(\'bar\').qux(\'zap\')', it, {input: 'foo(\'bar\').baz(\'zap\')'}
+
   suite 'filters' ->
     obj-input = '''
                 var obj = {


### PR DESCRIPTION
This change adds a test case for #62. Stepping through in the debugger
suggests that both selectors are run against the same AST. Since the
`_str$s` variable matches an AST nested inside the `$e` expression and
the `$e` expression appears first, the intended `_str$s` is not found.