### PR TITLE
'Maximum call stack size exceeded' error will now not be raised 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,7 +372,7 @@
             stat = fs.lstatSync(targetPath);
             if (stat.isDirectory() && options.recursive) {
               async.eachSeries(fs.readdirSync(targetPath), searchTarget(basePath, targetPath), function(){
-                async.setImmediate(function(){
+                return async.setImmediate(function(){
                   return done();
                 });
               });

--- a/lib/index.js
+++ b/lib/index.js
@@ -372,7 +372,9 @@
             stat = fs.lstatSync(targetPath);
             if (stat.isDirectory() && options.recursive) {
               async.eachSeries(fs.readdirSync(targetPath), searchTarget(basePath, targetPath), function(){
-                return done();
+                async.setImmediate(function(){
+                  return done();
+                });
               });
             } else if (stat.isFile() && testExt(target)) {
               fileContents = fs.readFileSync(targetPath, 'utf8');

--- a/src/index.ls
+++ b/src/index.ls
@@ -276,7 +276,8 @@ run = ({
           stat = fs.lstat-sync target-path
           if stat.is-directory! and options.recursive
             async.each-series (fs.readdir-sync target-path), (search-target base-path, target-path), ->
-              done!
+              async.setImmediate ->
+                done!
           else if stat.is-file! and test-ext target
             file-contents = fs.read-file-sync target-path, 'utf8'
             display-path = path.relative base-path, target-path


### PR DESCRIPTION
fixes #77

Changed `iterator` of `async.eachSeries` according to suggestions in https://github.com/caolan/async#synchronous-iteration-functions
