### PR TITLE
do not duplicate version in code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@
   ref$ = require('./options'), parseOptions = ref$.parse, generateHelp = ref$.generateHelp, generateHelpForOption = ref$.generateHelpForOption;
   help = require('./help');
   _console = console;
-  version = '0.4.0';
+  version = require('../package.json').version;
   run = function(arg$){
     var ref$, args, error, ref1$, callback, exit, data, stdin, fs, textFormat, input, console, options, positional, debug, e, versionString, getHelp, helpString, queryEngine, parser, parserOptions, that, selector, targets, targetsLen, replacement, isDir, color, bold, textFormatFuncs, resultsData, resultsFormat, callCallback, out, parsedSelector, resultsSortFunc, search, processResults, getToMap, end, exts, testExt, exclude, testExclude, targetPaths, searchTarget, cwd, this$ = this;
     ref$ = arg$ != null

--- a/src/index.ls
+++ b/src/index.ls
@@ -13,7 +13,7 @@ require! {
 help = require './help'
 _console = console
 
-version = '0.4.0'
+version = require('../package.json').version
 
 run = ({
   args


### PR DESCRIPTION
Version is already provided in package.json and can be read from there, instead of duplicating it in code.