### PR TITLE
use process.exitCode instead of process.exit,

### DIFF
--- a/bin/grasp
+++ b/bin/grasp
@@ -3,7 +3,7 @@ var path = require('path'),
     grasp = require(path.join(__dirname, '..', 'lib'));
 grasp({
   args: process.argv,
-  exit: process.exit,
+  exit: function(code){ process.exitCode = code },
   stdin: process.stdin,
   fs: require('fs'),
   callback: console.log,


### PR DESCRIPTION
to prevent problems with truncated output on ubuntu

solves #116 